### PR TITLE
Implement Debug for Header

### DIFF
--- a/src/http/tests/mod.rs
+++ b/src/http/tests/mod.rs
@@ -150,4 +150,14 @@ mod test_header {
             _ => {},
         };
     }
+
+    #[test]
+    fn test_debug() {
+        assert_eq!(
+            "Header { name: b\":method\", value: b\"GET\" }",
+            format!("{:?}", Header::new(b":method", b"GET")));
+        assert_eq!(
+            "Header { name: b\":method\", value: b\"\\xcd\" }",
+            format!("{:?}", Header::new(b":method", b"\xcd")));
+    }
 }


### PR DESCRIPTION
Print name and value as chars (when possible) instead of sequence of integers.