### PR TITLE
docs: minor typo in frame/headers

### DIFF
--- a/src/http/frame/headers.rs
+++ b/src/http/frame/headers.rs
@@ -1,4 +1,4 @@
-//! The module contains the implementation of the `SETTINGS` frame and associated flags.
+//! The module contains the implementation of the `HEADERS` frame and associated flags.
 
 use http::StreamId;
 use http::frame::{


### PR DESCRIPTION
For `HEADERS` frames, not `SETTINGS`