### PR TITLE
Prevent Solicit from choking on HTTP/2 Trailers

### DIFF
--- a/src/client/async.rs
+++ b/src/client/async.rs
@@ -14,12 +14,7 @@ use http::{StreamId, HttpError, Response, StaticResponse, Header, HttpResult, St
 use http::frame::{RawFrame, FrameIR};
 use http::transport::TransportStream;
 use http::connection::{SendFrame, ReceiveFrame, HttpFrame, HttpConnection};
-use http::session::{
-    SessionState,
-    DefaultSessionState,
-    DefaultStream,
-    Stream,
-};
+use http::session::{SessionState, DefaultSessionState, DefaultStream, Stream};
 use http::session::Client as ClientMarker;
 use http::client::{ClientConnection, HttpConnect, ClientStream, RequestStream};
 
@@ -50,7 +45,9 @@ struct AsyncRequest {
 /// As such, this is a convenience struct that makes it possible to provide non-blocking writes
 /// from within `HttpConnection`s, while handling the actual writes using a `SendFrame`
 /// implementation that will block until the frame is sent on a separate thread.
-struct ChannelFrameSender<S> where S: SendFrame {
+struct ChannelFrameSender<S>
+    where S: SendFrame
+{
     /// The receiving end of the channel. Buffers the frames that are to be sent.
     rx: Receiver<Vec<u8>>,
     /// The `SendFrame` instance that will perform the actual writes from within the `send_next`
@@ -58,7 +55,9 @@ struct ChannelFrameSender<S> where S: SendFrame {
     inner: S,
 }
 
-impl<S> ChannelFrameSender<S> where S: SendFrame {
+impl<S> ChannelFrameSender<S>
+    where S: SendFrame
+{
     /// Creates a new `ChannelFrameSender` that will use the provided `SendFrame` instance within
     /// the `send_next` method in order to perform the final send to the remote peer.
     /// The `ChannelFrameSenderHandle` that is returned can be used to queue frames for sending
@@ -81,12 +80,11 @@ impl<S> ChannelFrameSender<S> where S: SendFrame {
     /// If the channel becomes disconnected from all senders, indicating that all handles to the
     /// sender have been dropped, the mehod will return an error.
     fn send_next(&mut self) -> HttpResult<()> {
-        let frame_buffer = try!(
-            self.rx.recv()
-                   .map_err(|_| {
-                       io::Error::new(io::ErrorKind::Other, "Unable to send frame")
-                   })
-        );
+        let frame_buffer = try!(self.rx
+                                    .recv()
+                                    .map_err(|_| {
+                                        io::Error::new(io::ErrorKind::Other, "Unable to send frame")
+                                    }));
         debug!("Performing the actual send frame IO");
         let raw_frame: RawFrame = frame_buffer.into();
         try!(self.inner.send_frame(raw_frame));
@@ -107,10 +105,9 @@ impl SendFrame for ChannelFrameSenderHandle {
     fn send_frame<F: FrameIR>(&mut self, frame: F) -> HttpResult<()> {
         let mut buf = io::Cursor::new(Vec::with_capacity(1024));
         try!(frame.serialize_into(&mut buf));
-        try!(self.tx.send(buf.into_inner())
-                    .map_err(|_| {
-                        io::Error::new(io::ErrorKind::Other, "Unable to send frame")
-                    }));
+        try!(self.tx
+                 .send(buf.into_inner())
+                 .map_err(|_| io::Error::new(io::ErrorKind::Other, "Unable to send frame")));
         debug!("Queued the frame for sending...");
         Ok(())
     }
@@ -129,7 +126,9 @@ impl SendFrame for ChannelFrameSenderHandle {
 /// from within `HttpConnection`s, while handling the actual reads using a `ReceiveFrame`
 /// implementation that can block. (Predicated on triggering a single frame handle operation on
 /// the connection for each successfully executed `read_next`.)
-struct ChannelFrameReceiver<TS> where TS: TransportStream {
+struct ChannelFrameReceiver<TS>
+    where TS: TransportStream
+{
     /// The sender side of the channel. Buffers the frames read by the wrapped `ReceiveFrame`
     /// instance for future consumation by the associated `ChannelFrameReceiverHandle`.
     tx: Sender<RawFrame<'static>>,
@@ -139,13 +138,18 @@ struct ChannelFrameReceiver<TS> where TS: TransportStream {
 }
 
 use http::frame::unpack_header;
-impl<TS> ChannelFrameReceiver<TS> where TS: TransportStream {
+impl<TS> ChannelFrameReceiver<TS>
+    where TS: TransportStream
+{
     /// Creates a new `ChannelFrameReceiver`, as well as the associated
     /// `ChannelFrameReceiverHandle`.
     fn new(inner: TS) -> (ChannelFrameReceiver<TS>, ChannelFrameReceiverHandle) {
         let (send, recv) = mpsc::channel();
 
-        let handle = ChannelFrameReceiverHandle { rx: recv, raw: None };
+        let handle = ChannelFrameReceiverHandle {
+            rx: recv,
+            raw: None,
+        };
         let receiver = ChannelFrameReceiver {
             tx: send,
             inner: inner,
@@ -161,13 +165,14 @@ impl<TS> ChannelFrameReceiver<TS> where TS: TransportStream {
         try!(TransportStream::read_exact(&mut self.inner, &mut header));
         let total_len = unpack_header(&header).0 as usize;
         let mut buf = Vec::with_capacity(9 + total_len);
-        unsafe { buf.set_len(9 + total_len); }
+        unsafe {
+            buf.set_len(9 + total_len);
+        }
         try!(io::copy(&mut &header[..], &mut &mut buf[..9]));
         try!(TransportStream::read_exact(&mut self.inner, &mut buf[9..]));
-        try!(self.tx.send(buf.into())
-                    .map_err(|_| {
-                        io::Error::new(io::ErrorKind::Other, "Unable to read frame")
-                    }));
+        try!(self.tx
+                 .send(buf.into())
+                 .map_err(|_| io::Error::new(io::ErrorKind::Other, "Unable to read frame")));
         Ok(())
     }
 }
@@ -187,10 +192,12 @@ struct ChannelFrameReceiverHandle {
 
 impl ReceiveFrame for ChannelFrameReceiverHandle {
     fn recv_frame(&mut self) -> HttpResult<HttpFrame> {
-        let raw = try!(self.rx.recv()
-            .map_err(|_| {
-                HttpError::from(io::Error::new(io::ErrorKind::Other, "Unable to read frame"))
-            }));
+        let raw = try!(self.rx
+                           .recv()
+                           .map_err(|_| {
+                               HttpError::from(io::Error::new(io::ErrorKind::Other,
+                                                              "Unable to read frame"))
+                           }));
         // Tethers the lifetime of the returned parsed HttpFrame to the lifetime of `self` (i.e.
         // the provider of the frame).
         self.raw = Some(raw);
@@ -209,7 +216,9 @@ enum ClientServiceErr {
 }
 
 impl From<HttpError> for ClientServiceErr {
-    fn from(err: HttpError) -> ClientServiceErr { ClientServiceErr::Http(err) }
+    fn from(err: HttpError) -> ClientServiceErr {
+        ClientServiceErr::Http(err)
+    }
 }
 
 /// An enum representing the types of work that the `ClientService` can perform from within its
@@ -293,11 +302,8 @@ struct ClientService {
 
 /// A helper wrapper around the components of the `ClientService` that are returned from its
 /// constructor.
-struct Service<S>(
-    ClientService,
-    Sender<WorkItem>,
-    ChannelFrameReceiver<S>,
-    ChannelFrameSender<S>) where S: TransportStream;
+struct Service<S>(ClientService, Sender<WorkItem>, ChannelFrameReceiver<S>, ChannelFrameSender<S>)
+    where S: TransportStream;
 
 impl ClientService {
     /// Creates a new `ClientService` that will use the provided `ClientStream` for its underlying
@@ -323,9 +329,9 @@ impl ClientService {
     /// If no HTTP/2 connection can be established to the given host on the
     /// given port, returns `None`.
     pub fn new<S>(client_stream: ClientStream<S>) -> Option<Service<S>>
-            where S: TransportStream {
-        let (tx, rx): (Sender<WorkItem>, Receiver<WorkItem>) =
-                mpsc::channel();
+        where S: TransportStream
+    {
+        let (tx, rx): (Sender<WorkItem>, Receiver<WorkItem>) = mpsc::channel();
         let ClientStream(stream, scheme, host) = client_stream;
 
         // Manually split the stream into the write/read ends, so that we can...
@@ -337,9 +343,8 @@ impl ClientService {
 
         // ...and pass the non-blocking/buffering ends into the `HttpConnect` instead of the
         // blocking socket itself.
-        let conn = ClientConnection::with_connection(
-                HttpConnection::new(scheme),
-                DefaultSessionState::<ClientMarker, _>::new());
+        let conn = ClientConnection::with_connection(HttpConnection::new(scheme),
+                                                     DefaultSessionState::<ClientMarker, _>::new());
 
         let service = ClientService {
             outstanding_reqs: 0,
@@ -408,7 +413,7 @@ impl ClientService {
                 self.request_queue.push(async_req);
                 self.queue_next_request();
                 Ok(())
-            },
+            }
             WorkItem::HandleFrame => {
                 if !self.initialized {
                     try!(self.conn.expect_settings(&mut self.recv_handle, &mut self.send_handle));
@@ -417,7 +422,7 @@ impl ClientService {
                 } else {
                     self.handle_frame()
                 }
-            },
+            }
             WorkItem::SendData => {
                 debug!("Will queue some request data");
                 try!(self.conn.send_next_data(&mut self.send_handle));
@@ -426,7 +431,7 @@ impl ClientService {
             WorkItem::NewClient => {
                 self.client_count += 1;
                 Ok(())
-            },
+            }
             WorkItem::ClientLeft => {
                 self.client_count -= 1;
                 if self.client_count == 0 {
@@ -481,15 +486,18 @@ impl ClientService {
     /// the connection for transmission to the server (i.e. `start_request`).
     /// Also returns the sender end of the channel to which the response is to be transmitted,
     /// once received.
-    fn create_request(&self, async_req: AsyncRequest)
-            -> (RequestStream<'static, 'static, DefaultStream>, Sender<StaticResponse>) {
+    fn create_request(&self,
+                      async_req: AsyncRequest)
+                      -> (RequestStream<'static, 'static, DefaultStream>,
+                          Sender<StaticResponse>) {
         let mut headers: Vec<Header> = Vec::new();
         headers.extend(vec![
             Header::new(b":method", async_req.method),
             Header::new(b":path", async_req.path),
             Header::new(b":authority", self.host.clone()),
             Header::new(b":scheme", self.conn.scheme().as_bytes().to_vec()),
-        ].into_iter());
+        ]
+                           .into_iter());
         headers.extend(async_req.headers.into_iter());
 
         let mut stream = DefaultStream::new();
@@ -498,13 +506,11 @@ impl ClientService {
             None => stream.close_local(),
         };
 
-        (
-            RequestStream {
-                stream: stream,
-                headers: headers,
-            },
-            async_req.tx
-        )
+        (RequestStream {
+            stream: stream,
+            headers: headers,
+        },
+         async_req.tx)
     }
 
     /// Internal helper method. Sends a response assembled from the given
@@ -518,7 +524,7 @@ impl ClientService {
                 // This should never happen, it means the session gave us
                 // a response that we didn't request.
                 panic!("Received a response for an unknown request!");
-            },
+            }
             Some(tx) => {
                 let _ = tx.send(Response {
                     stream_id: stream_id,
@@ -604,9 +610,7 @@ pub struct Client {
 impl Clone for Client {
     fn clone(&self) -> Client {
         self.sender.send(WorkItem::NewClient).unwrap();
-        Client {
-            sender: self.sender.clone(),
-        }
+        Client { sender: self.sender.clone() }
     }
 }
 
@@ -636,7 +640,9 @@ impl Client {
     ///
     /// If the HTTP/2 connection cannot be initialized returns `None`.
     pub fn with_connector<C, S>(connector: C) -> Option<Client>
-            where C: HttpConnect<Stream=S>, S: TransportStream + Send + 'static {
+        where C: HttpConnect<Stream = S>,
+              S: TransportStream + Send + 'static
+    {
         // Use the provided connector to establish a network connection...
         let client_stream = connector.connect().ok().unwrap();
         // Keep a socket handle in order to shut it down once the service stops. This is required
@@ -682,9 +688,7 @@ impl Client {
             debug!("Reader thread halting");
         });
 
-        Some(Client {
-            sender: rx,
-        })
+        Some(Client { sender: rx })
     }
 
     /// Issues a new request to the server.
@@ -707,15 +711,14 @@ impl Client {
     /// If the method is unable to queue the request, it must mean that the
     /// underlying HTTP/2 connection to which this client is associated has
     /// failed and it returns `None`.
-    pub fn request(
-            &self,
-            method: &[u8],
-            path: &[u8],
-            headers: &[StaticHeader],
-            body: Option<Vec<u8>>)
-            -> Option<Receiver<StaticResponse>> {
+    pub fn request(&self,
+                   method: &[u8],
+                   path: &[u8],
+                   headers: &[StaticHeader],
+                   body: Option<Vec<u8>>)
+                   -> Option<Receiver<StaticResponse>> {
         let (resp_tx, resp_rx): (Sender<StaticResponse>, Receiver<StaticResponse>) =
-                mpsc::channel();
+            mpsc::channel();
         // A send can only fail if the receiver is disconnected. If the send
         // fails here, it means that the service hit an error on the underlying
         // HTTP/2 connection and will never come alive again.
@@ -744,8 +747,11 @@ impl Client {
     /// Issues a POST request to the server.
     ///
     /// Returns the receiving end of a channel where the `Response` will eventually be pushed.
-    pub fn post(&self, path: &[u8], headers: &[StaticHeader], body: Vec<u8>)
-            -> Option<Receiver<StaticResponse>> {
+    pub fn post(&self,
+                path: &[u8],
+                headers: &[StaticHeader],
+                body: Vec<u8>)
+                -> Option<Receiver<StaticResponse>> {
         self.request(b"POST", path, headers, Some(body))
     }
 }

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -7,4 +7,4 @@ pub use self::async::Client;
 
 mod simple;
 mod async;
-#[cfg(test)] mod tests;
+#[cfg(test)]mod tests;

--- a/src/client/tests.rs
+++ b/src/client/tests.rs
@@ -68,13 +68,15 @@ mod async {
     /// The requests are all issued concurrently (spawning as many threads as there are requests).
     fn get(host: &str, paths: &[String]) -> Vec<Response<'static, 'static>> {
         let client = Client::with_connector(CleartextConnector::new(host)).unwrap();
-        let threads: Vec<_> = paths.iter().map(|path| {
-            let this = client.clone();
-            let path = path.clone();
-            thread::spawn(move || {
-                this.get(path.as_bytes(), &[]).unwrap().recv().unwrap()
-            })
-        }).collect();
+        let threads: Vec<_> = paths.iter()
+                                   .map(|path| {
+                                       let this = client.clone();
+                                       let path = path.clone();
+                                       thread::spawn(move || {
+                                           this.get(path.as_bytes(), &[]).unwrap().recv().unwrap()
+                                       })
+                                   })
+                                   .collect();
 
         threads.into_iter().map(|t| t.join().unwrap()).collect()
     }

--- a/src/http/client/tls.rs
+++ b/src/http/client/tls.rs
@@ -120,11 +120,13 @@ pub enum TlsConnectError {
 impl fmt::Debug for TlsConnectError {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         // The enum variant...
-        try!(write!(fmt, "TlsConnectError::{}", match *self {
-            TlsConnectError::IoError(_) => "IoError",
-            TlsConnectError::SslError(_) => "SslError",
-            TlsConnectError::Http2NotSupported(_) => "Http2NotSupported",
-        }));
+        try!(write!(fmt,
+                    "TlsConnectError::{}",
+                    match *self {
+                        TlsConnectError::IoError(_) => "IoError",
+                        TlsConnectError::SslError(_) => "SslError",
+                        TlsConnectError::Http2NotSupported(_) => "Http2NotSupported",
+                    }));
         // ...and the wrapped value, except for when it's the stream.
         match *self {
             TlsConnectError::IoError(ref err) => try!(write!(fmt, "({:?})", err)),
@@ -138,7 +140,9 @@ impl fmt::Debug for TlsConnectError {
 
 impl fmt::Display for TlsConnectError {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
-        write!(fmt, "TLS HTTP/2 connect error: {}", (self as &error::Error).description())
+        write!(fmt,
+               "TLS HTTP/2 connect error: {}",
+               (self as &error::Error).description())
     }
 }
 
@@ -225,7 +229,7 @@ impl<'a, 'ctx> HttpConnect for TlsConnector<'a, 'ctx> {
             Http2TlsContext::CertPath(path) => {
                 let ctx = try!(TlsConnector::build_default_context(&path));
                 try!(Ssl::new(&ctx))
-            },
+            }
             Http2TlsContext::Wrapped(ctx) => try!(Ssl::new(ctx)),
         };
         // SNI must be used

--- a/src/http/frame/builder.rs
+++ b/src/http/frame/builder.rs
@@ -1,10 +1,7 @@
 //! Defines the `FrameBuilder` trait and some default implementations of the trait.
 
 use std::io;
-use http::frame::{
-    FrameHeader,
-    pack_header,
-};
+use http::frame::{FrameHeader, pack_header};
 
 /// A trait that provides additional methods for serializing HTTP/2 frames.
 ///
@@ -37,7 +34,8 @@ pub trait FrameBuilder: io::Write + io::Seek {
     /// efficiently than the `io::copy` function does (i.e. without the intermediate read into a
     /// stack-allocated buffer).
     fn copy_bytes_from<R: io::Read>(&mut self, provider: &mut R) -> io::Result<u64>
-            where Self: Sized {
+        where Self: Sized
+    {
         io::copy(provider, self)
     }
 
@@ -50,19 +48,19 @@ pub trait FrameBuilder: io::Write + io::Seek {
     /// known that the `FrameBuilder` is backed by a zeroed buffer, there's no need to write
     /// anything, only increment a cursor/offset).
     fn write_padding(&mut self, padding_length: u8) -> io::Result<()> {
-        for _ in 0..padding_length { try!(self.write_all(&[0])); }
+        for _ in 0..padding_length {
+            try!(self.write_all(&[0]));
+        }
         Ok(())
     }
 
     /// Write the given unsigned 32 bit integer to the underlying stream. The integer is written as
     /// four bytes in network endian style.
     fn write_u32(&mut self, num: u32) -> io::Result<()> {
-        self.write_all(&[
-            (((num >> 24) & 0x000000FF) as u8),
-            (((num >> 16) & 0x000000FF) as u8),
-            (((num >>  8) & 0x000000FF) as u8),
-            (((num >>  0) & 0x000000FF) as u8),
-        ])
+        self.write_all(&[(((num >> 24) & 0x000000FF) as u8),
+                         (((num >> 16) & 0x000000FF) as u8),
+                         (((num >> 8) & 0x000000FF) as u8),
+                         (((num >> 0) & 0x000000FF) as u8)])
     }
 }
 
@@ -72,7 +70,7 @@ impl FrameBuilder for io::Cursor<Vec<u8>> {}
 mod tests {
     use super::FrameBuilder;
     use std::io::{self, Write};
-    use http::frame::{pack_header};
+    use http::frame::pack_header;
 
     #[test]
     fn test_write_header_empty_buffer() {

--- a/src/http/frame/data.rs
+++ b/src/http/frame/data.rs
@@ -3,15 +3,7 @@
 use std::io;
 use std::borrow::Cow;
 use http::StreamId;
-use http::frame::{
-    FrameBuilder,
-    FrameIR,
-    Flag,
-    Frame,
-    FrameHeader,
-    RawFrame,
-    parse_padded_payload,
-};
+use http::frame::{FrameBuilder, FrameIR, Flag, Frame, FrameHeader, RawFrame, parse_padded_payload};
 
 /// An enum representing the flags that a `DataFrame` can have.
 /// The integer representation associated to each variant is that flag's
@@ -138,8 +130,7 @@ impl<'a> DataFrame<'a> {
     /// If there was no padding, returns `None` for the second tuple member.
     ///
     /// If the payload was invalid for a DATA frame, returns `None`
-    fn parse_payload(payload: &[u8], padded: bool)
-            -> Option<(&[u8], Option<u8>)> {
+    fn parse_payload(payload: &[u8], padded: bool) -> Option<(&[u8], Option<u8>)> {
         let (data, pad_len) = if padded {
             match parse_padded_payload(payload) {
                 Some((data, pad_len)) => (data, Some(pad_len)),
@@ -195,7 +186,7 @@ impl<'a> Frame<'a> for DataFrame<'a> {
                     data: Cow::Borrowed(data),
                     padding_len: Some(padding_len),
                 })
-            },
+            }
             Some((data, None)) => {
                 // The data got extracted (from a no-padding frame)
                 Some(DataFrame {
@@ -204,7 +195,7 @@ impl<'a> Frame<'a> for DataFrame<'a> {
                     data: Cow::Borrowed(data),
                     padding_len: None,
                 })
-            },
+            }
             None => None,
         }
     }
@@ -243,7 +234,7 @@ impl<'a> FrameIR for DataFrame<'a> {
 #[cfg(test)]
 mod tests {
     use super::{DataFlag, DataFrame};
-    use http::frame::tests::{build_padded_frame_payload};
+    use http::frame::tests::build_padded_frame_payload;
     use http::tests::common::{raw_frame_from_parts, serialize_frame};
     use http::frame::{pack_header, Frame};
 
@@ -469,7 +460,9 @@ mod tests {
             // Data
             res.extend(data.clone());
             // Actual padding
-            for _ in 0..5 { res.push(0); }
+            for _ in 0..5 {
+                res.push(0);
+            }
 
             res
         };

--- a/src/http/frame/goaway.rs
+++ b/src/http/frame/goaway.rs
@@ -3,15 +3,7 @@
 use std::io;
 
 use http::{ErrorCode, StreamId};
-use http::frame::{
-    Frame,
-    FrameIR,
-    FrameBuilder,
-    FrameHeader,
-    RawFrame,
-    NoFlag,
-    parse_stream_id,
-};
+use http::frame::{Frame, FrameIR, FrameBuilder, FrameHeader, RawFrame, NoFlag, parse_stream_id};
 
 /// The minimum size for the `GOAWAY` frame payload.
 /// It is 8 octets, as the last stream id and error code are required parts of the GOAWAY frame.
@@ -40,11 +32,7 @@ impl<'a> GoawayFrame<'a> {
     }
 
     /// Create a new `GOAWAY` frame with the given parts.
-    pub fn with_debug_data(
-            last_stream_id: StreamId,
-            raw_error: u32,
-            debug_data: &'a [u8])
-            -> Self {
+    pub fn with_debug_data(last_stream_id: StreamId, raw_error: u32, debug_data: &'a [u8]) -> Self {
         GoawayFrame {
             last_stream_id: last_stream_id,
             raw_error_code: raw_error,
@@ -112,8 +100,12 @@ impl<'a> Frame<'a> for GoawayFrame<'a> {
         })
     }
 
-    fn is_set(&self, _: NoFlag) -> bool { false }
-    fn get_stream_id(&self) -> StreamId { 0 }
+    fn is_set(&self, _: NoFlag) -> bool {
+        false
+    }
+    fn get_stream_id(&self) -> StreamId {
+        0
+    }
     fn get_header(&self) -> FrameHeader {
         (self.payload_len(), GOAWAY_FRAME_TYPE, self.flags, 0)
     }
@@ -184,7 +176,8 @@ mod tests {
     #[test]
     fn test_parse_invalid_stream_id() {
         let raw = raw_frame_from_parts((8, 0x7, 0, 3), vec![0, 0, 0, 0, 0, 0, 0, 1]);
-        assert!(GoawayFrame::from_raw(&raw).is_none(), "expected invalid stream id");
+        assert!(GoawayFrame::from_raw(&raw).is_none(),
+                "expected invalid stream id");
     }
 
     #[test]
@@ -197,8 +190,8 @@ mod tests {
     #[test]
     fn test_serialize_no_debug_data() {
         let frame = GoawayFrame::new(0, ErrorCode::ProtocolError);
-        let expected: Vec<u8> =
-            raw_frame_from_parts((8, 0x7, 0, 0), vec![0, 0, 0, 0, 0, 0, 0, 1]).into();
+        let expected: Vec<u8> = raw_frame_from_parts((8, 0x7, 0, 0), vec![0, 0, 0, 0, 0, 0, 0, 1])
+                                    .into();
         let raw = serialize_frame(&frame);
 
         assert_eq!(expected, raw);
@@ -206,11 +199,11 @@ mod tests {
 
     #[test]
     fn test_serialize_with_debug_data() {
-        let frame = GoawayFrame::with_debug_data(
-            0, ErrorCode::ProtocolError.into(), b"Hi!");
-        let expected: Vec<u8> = raw_frame_from_parts(
-            (11, 0x7, 0, 0),
-            vec![0, 0, 0, 0, 0, 0, 0, 1, b'H', b'i', b'!']).into();
+        let frame = GoawayFrame::with_debug_data(0, ErrorCode::ProtocolError.into(), b"Hi!");
+        let expected: Vec<u8> = raw_frame_from_parts((11, 0x7, 0, 0),
+                                                     vec![0, 0, 0, 0, 0, 0, 0, 1, b'H', b'i',
+                                                          b'!'])
+                                    .into();
         let raw = serialize_frame(&frame);
 
         assert_eq!(expected, raw);
@@ -218,11 +211,10 @@ mod tests {
 
     #[test]
     fn test_serialize_raw_error() {
-        let frame = GoawayFrame::with_debug_data(
-            1, 0x0001AA, &[]);
-        let expected: Vec<u8> = raw_frame_from_parts(
-            (8, 0x7, 0, 0),
-            vec![0, 0, 0, 1, 0, 0, 0x1, 0xAA]).into();
+        let frame = GoawayFrame::with_debug_data(1, 0x0001AA, &[]);
+        let expected: Vec<u8> = raw_frame_from_parts((8, 0x7, 0, 0),
+                                                     vec![0, 0, 0, 1, 0, 0, 0x1, 0xAA])
+                                    .into();
         let raw = serialize_frame(&frame);
 
         assert_eq!(expected, raw);

--- a/src/http/frame/headers.rs
+++ b/src/http/frame/headers.rs
@@ -4,15 +4,7 @@ use std::io;
 use std::borrow::Cow;
 
 use http::StreamId;
-use http::frame::{
-    FrameBuilder,
-    FrameIR,
-    Flag,
-    Frame,
-    FrameHeader,
-    RawFrame,
-    parse_padded_payload,
-};
+use http::frame::{FrameBuilder, FrameIR, Flag, Frame, FrameHeader, RawFrame, parse_padded_payload};
 
 /// An enum representing the flags that a `HeadersFrame` can have.
 /// The integer representation associated to each variant is that flag's
@@ -56,8 +48,7 @@ pub struct StreamDependency {
 impl StreamDependency {
     /// Creates a new `StreamDependency` with the given stream ID, weight, and
     /// exclusivity.
-    pub fn new(stream_id: StreamId, weight: u8, is_exclusive: bool)
-            -> StreamDependency {
+    pub fn new(stream_id: StreamId, weight: u8, is_exclusive: bool) -> StreamDependency {
         StreamDependency {
             stream_id: stream_id,
             weight: weight,
@@ -112,13 +103,11 @@ impl StreamDependency {
         } else {
             0
         };
-        [
-            (((self.stream_id >> 24) & 0x000000FF) as u8) | e_bit,
-            (((self.stream_id >> 16) & 0x000000FF) as u8),
-            (((self.stream_id >>  8) & 0x000000FF) as u8),
-            (((self.stream_id >>  0) & 0x000000FF) as u8),
-            self.weight,
-        ]
+        [(((self.stream_id >> 24) & 0x000000FF) as u8) | e_bit,
+         (((self.stream_id >> 16) & 0x000000FF) as u8),
+         (((self.stream_id >> 8) & 0x000000FF) as u8),
+         (((self.stream_id >> 0) & 0x000000FF) as u8),
+         self.weight]
     }
 }
 
@@ -155,10 +144,10 @@ impl<'a> HeadersFrame<'a> {
 
     /// Creates a new `HeadersFrame` with the given header fragment, stream ID
     /// and stream dependency information. No padding and no flags are set.
-    pub fn with_dependency(
-            fragment: Vec<u8>,
-            stream_id: StreamId,
-            stream_dep: StreamDependency) -> HeadersFrame<'a> {
+    pub fn with_dependency(fragment: Vec<u8>,
+                           stream_id: StreamId,
+                           stream_dep: StreamDependency)
+                           -> HeadersFrame<'a> {
         HeadersFrame {
             header_fragment: Cow::Owned(fragment),
             stream_id: stream_id,
@@ -204,7 +193,9 @@ impl<'a> HeadersFrame<'a> {
         self.header_fragment.len() as u32 + priority + padding
     }
 
-    pub fn header_fragment(&self) -> &[u8] { &self.header_fragment }
+    pub fn header_fragment(&self) -> &[u8] {
+        &self.header_fragment
+    }
 
     /// Sets the given flag for the frame.
     pub fn set_flag(&mut self, flag: HeadersFlag) {
@@ -321,7 +312,7 @@ impl<'a> FrameIR for HeadersFrame<'a> {
 #[cfg(test)]
 mod tests {
     use super::{HeadersFrame, HeadersFlag, StreamDependency};
-    use http::frame::tests::{build_padded_frame_payload};
+    use http::frame::tests::build_padded_frame_payload;
     use http::tests::common::{raw_frame_from_parts, serialize_frame};
     use http::frame::{pack_header, Frame};
 
@@ -500,7 +491,7 @@ mod tests {
 
         let raw = raw_frame_from_parts(header, payload);
         let frame: Option<HeadersFrame> = Frame::from_raw(&raw);
-        
+
         assert!(frame.is_none());
     }
 
@@ -514,7 +505,7 @@ mod tests {
 
         let raw = raw_frame_from_parts(header, payload);
         let frame: Option<HeadersFrame> = Frame::from_raw(&raw);
-        
+
         assert!(frame.is_none());
     }
 

--- a/src/http/frame/mod.rs
+++ b/src/http/frame/mod.rs
@@ -74,10 +74,8 @@ pub type FrameHeader = (u32, u8, u8, u32);
 /// The frame `type` and `flags` components are returned as their original
 /// octet representation, rather than reinterpreted.
 pub fn unpack_header(header: &FrameHeaderBuffer) -> FrameHeader {
-    let length: u32 =
-        ((header[0] as u32) << 16) |
-        ((header[1] as u32) <<  8) |
-        ((header[2] as u32) <<  0);
+    let length: u32 = ((header[0] as u32) << 16) | ((header[1] as u32) << 8) |
+                      ((header[2] as u32) << 0);
     let frame_type = header[3];
     let flags = header[4];
     let stream_id = parse_stream_id(&header[5..]);
@@ -89,17 +87,15 @@ pub fn unpack_header(header: &FrameHeaderBuffer) -> FrameHeader {
 pub fn pack_header(header: &FrameHeader) -> FrameHeaderBuffer {
     let &(length, frame_type, flags, stream_id) = header;
 
-    [
-        (((length >> 16) & 0x000000FF) as u8),
-        (((length >>  8) & 0x000000FF) as u8),
-        (((length >>  0) & 0x000000FF) as u8),
-        frame_type,
-        flags,
-        (((stream_id >> 24) & 0x000000FF) as u8),
-        (((stream_id >> 16) & 0x000000FF) as u8),
-        (((stream_id >>  8) & 0x000000FF) as u8),
-        (((stream_id >>  0) & 0x000000FF) as u8),
-    ]
+    [(((length >> 16) & 0x000000FF) as u8),
+     (((length >> 8) & 0x000000FF) as u8),
+     (((length >> 0) & 0x000000FF) as u8),
+     frame_type,
+     flags,
+     (((stream_id >> 24) & 0x000000FF) as u8),
+     (((stream_id >> 16) & 0x000000FF) as u8),
+     (((stream_id >> 8) & 0x000000FF) as u8),
+     (((stream_id >> 0) & 0x000000FF) as u8)]
 }
 
 /// A helper function that parses the given payload, considering it padded.
@@ -150,7 +146,9 @@ pub trait Flag {
 /// A helper struct that can be used by all frames that do not define any flags.
 pub struct NoFlag;
 impl Flag for NoFlag {
-    fn bitmask(&self) -> u8 { 0 }
+    fn bitmask(&self) -> u8 {
+        0
+    }
 }
 
 /// A trait that all HTTP/2 frame structs need to implement.
@@ -287,20 +285,28 @@ impl<'a> RawFrame<'a> {
 }
 
 impl<'a> Into<Vec<u8>> for RawFrame<'a> {
-    fn into(self) -> Vec<u8> { self.raw_content.into_owned() }
+    fn into(self) -> Vec<u8> {
+        self.raw_content.into_owned()
+    }
 }
 impl<'a> AsRef<[u8]> for RawFrame<'a> {
-    fn as_ref(&self) -> &[u8] { self.raw_content.as_ref() }
+    fn as_ref(&self) -> &[u8] {
+        self.raw_content.as_ref()
+    }
 }
 /// Provide a conversion from a `Vec`.
 ///
 /// This conversion is unchecked and could cause the resulting `RawFrame` to be an
 /// invalid HTTP/2 frame.
 impl<'a> From<Vec<u8>> for RawFrame<'a> {
-    fn from(raw: Vec<u8>) -> RawFrame<'a> { RawFrame { raw_content: Cow::Owned(raw) } }
+    fn from(raw: Vec<u8>) -> RawFrame<'a> {
+        RawFrame { raw_content: Cow::Owned(raw) }
+    }
 }
 impl<'a> From<&'a [u8]> for RawFrame<'a> {
-    fn from(raw: &'a [u8]) -> RawFrame<'a> { RawFrame { raw_content: Cow::Borrowed(raw) } }
+    fn from(raw: &'a [u8]) -> RawFrame<'a> {
+        RawFrame { raw_content: Cow::Borrowed(raw) }
+    }
 }
 
 /// `RawFrame`s can be serialized to an on-the-wire format.
@@ -313,12 +319,7 @@ impl<'a> FrameIR for RawFrame<'a> {
 
 #[cfg(test)]
 mod tests {
-    use super::{
-        unpack_header,
-        pack_header,
-        RawFrame,
-        FrameIR,
-    };
+    use super::{unpack_header, pack_header, RawFrame, FrameIR};
     use std::io;
 
     /// Tests that the `unpack_header` function correctly returns the
@@ -359,9 +360,8 @@ mod tests {
         }
         {
             let header = [0xFF, 0xFF, 0xFF, 0, 0, 1, 1, 1, 1];
-            assert_eq!(
-                ((1 << 24) - 1, 0, 0, 1 + (1 << 8) + (1 << 16) + (1 << 24)),
-                unpack_header(&header));
+            assert_eq!(((1 << 24) - 1, 0, 0, 1 + (1 << 8) + (1 << 16) + (1 << 24)),
+                       unpack_header(&header));
         }
         {
             // Ignores reserved bit within the stream id (the most significant bit)
@@ -408,9 +408,7 @@ mod tests {
         }
         {
             let header = [0xFF, 0xFF, 0xFF, 0, 0, 1, 1, 1, 1];
-            let header_components = (
-                (1 << 24) - 1, 0, 0, 1 + (1 << 8) + (1 << 16) + (1 << 24)
-            );
+            let header_components = ((1 << 24) - 1, 0, 0, 1 + (1 << 8) + (1 << 16) + (1 << 24));
             assert_eq!(pack_header(&header_components), header);
         }
     }
@@ -424,7 +422,9 @@ mod tests {
         let mut payload: Vec<u8> = Vec::with_capacity(sz);
         payload.push(pad_len);
         payload.extend(data.to_vec().into_iter());
-        for _ in 0..pad_len { payload.push(0); }
+        for _ in 0..pad_len {
+            payload.push(0);
+        }
 
         payload
     }

--- a/src/http/frame/rst_stream.rs
+++ b/src/http/frame/rst_stream.rs
@@ -2,14 +2,7 @@
 use std::io;
 
 use http::{ErrorCode, StreamId};
-use http::frame::{
-    Frame,
-    FrameIR,
-    FrameBuilder,
-    FrameHeader,
-    RawFrame,
-    NoFlag,
-};
+use http::frame::{Frame, FrameIR, FrameBuilder, FrameHeader, RawFrame, NoFlag};
 
 /// The total allowed size for the `RST_STREAM` frame payload.
 pub const RST_STREAM_FRAME_LEN: u32 = 4;
@@ -80,10 +73,17 @@ impl<'a> Frame<'a> for RstStreamFrame {
         })
     }
 
-    fn is_set(&self, _: NoFlag) -> bool { false }
-    fn get_stream_id(&self) -> StreamId { self.stream_id }
+    fn is_set(&self, _: NoFlag) -> bool {
+        false
+    }
+    fn get_stream_id(&self) -> StreamId {
+        self.stream_id
+    }
     fn get_header(&self) -> FrameHeader {
-        (RST_STREAM_FRAME_LEN, RST_STREAM_FRAME_TYPE, self.flags, self.stream_id)
+        (RST_STREAM_FRAME_LEN,
+         RST_STREAM_FRAME_TYPE,
+         self.flags,
+         self.stream_id)
     }
 }
 
@@ -101,11 +101,7 @@ mod tests {
 
     use http::tests::common::serialize_frame;
     use http::ErrorCode;
-    use http::frame::{
-        pack_header,
-        FrameHeader,
-        Frame,
-    };
+    use http::frame::{pack_header, FrameHeader, Frame};
 
     /// A helper function that creates a new Vec containing the serialized representation of the
     /// given `FrameHeader` followed by the raw provided payload.
@@ -182,7 +178,8 @@ mod tests {
     fn test_serialize_raw_error_code() {
         let frame = RstStreamFrame::with_raw_error_code(3, 1024);
         let raw = serialize_frame(&frame);
-        assert_eq!(raw, prepare_frame_bytes((4, 0x3, 0, 3), vec![0, 0, 0x04, 0]));
+        assert_eq!(raw,
+                   prepare_frame_bytes((4, 0x3, 0, 3), vec![0, 0, 0x04, 0]));
     }
 
     #[test]

--- a/src/http/frame/settings.rs
+++ b/src/http/frame/settings.rs
@@ -2,14 +2,7 @@
 
 use std::io;
 use http::StreamId;
-use http::frame::{
-    FrameBuilder,
-    FrameIR,
-    Flag,
-    Frame,
-    FrameHeader,
-    RawFrame,
-};
+use http::frame::{FrameBuilder, FrameIR, Flag, Frame, FrameHeader, RawFrame};
 
 /// An enum that lists all valid settings that can be sent in a SETTINGS
 /// frame.
@@ -90,14 +83,12 @@ impl HttpSetting {
     /// according to section 6.5.1.
     fn serialize(&self) -> [u8; 6] {
         let (id, val) = (self.get_id(), self.get_val());
-        [
-            ((id >> 8) & 0x00FF) as u8,
-            ((id >> 0) & 0x00FF) as u8,
-            (((val >> 24) & 0x000000FF) as u8),
-            (((val >> 16) & 0x000000FF) as u8),
-            (((val >>  8) & 0x000000FF) as u8),
-            (((val >>  0) & 0x000000FF) as u8),
-        ]
+        [((id >> 8) & 0x00FF) as u8,
+         ((id >> 0) & 0x00FF) as u8,
+         (((val >> 24) & 0x000000FF) as u8),
+         (((val >> 16) & 0x000000FF) as u8),
+         (((val >> 8) & 0x000000FF) as u8),
+         (((val >> 0) & 0x000000FF) as u8)]
     }
 }
 
@@ -210,9 +201,9 @@ impl SettingsFrame {
 
         // Iterates through chunks of the raw payload of size 6 bytes and
         // parses each of them into an `HttpSetting`
-        Some(payload.chunks(6).filter_map(|chunk| {
-            HttpSetting::parse_setting(chunk)
-        }).collect())
+        Some(payload.chunks(6)
+                    .filter_map(|chunk| HttpSetting::parse_setting(chunk))
+                    .collect())
     }
 
     /// Sets the given flag for the frame.
@@ -273,7 +264,7 @@ impl<'a> Frame<'a> for SettingsFrame {
                     settings: settings,
                     flags: flags,
                 })
-            },
+            }
             None => None,
         }
     }
@@ -341,7 +332,9 @@ mod tests {
         ];
         let payload = {
             let mut res: Vec<u8> = Vec::new();
-            for s in settings.iter().map(|s| s.serialize()) { res.extend(s.to_vec().into_iter()); }
+            for s in settings.iter().map(|s| s.serialize()) {
+                res.extend(s.to_vec().into_iter());
+            }
 
             res
         };
@@ -369,7 +362,9 @@ mod tests {
         ];
         let payload = {
             let mut res: Vec<u8> = Vec::new();
-            for s in settings.iter().map(|s| s.serialize()) { res.extend(s.to_vec().into_iter()); }
+            for s in settings.iter().map(|s| s.serialize()) {
+                res.extend(s.to_vec().into_iter());
+            }
 
             res
         };
@@ -396,9 +391,13 @@ mod tests {
         ];
         let payload = {
             let mut res: Vec<u8> = Vec::new();
-            for s in settings.iter().map(|s| s.serialize()) { res.extend(s.to_vec().into_iter()); }
+            for s in settings.iter().map(|s| s.serialize()) {
+                res.extend(s.to_vec().into_iter());
+            }
             res.extend(vec![0, 10, 0, 0, 0, 0].into_iter());
-            for s in settings.iter().map(|s| s.serialize()) { res.extend(s.to_vec().into_iter()); }
+            for s in settings.iter().map(|s| s.serialize()) {
+                res.extend(s.to_vec().into_iter());
+            }
 
             res
         };
@@ -439,12 +438,12 @@ mod tests {
     /// considered invalid.
     #[test]
     fn test_settings_frame_parse_ack_with_settings() {
-        let settings = [
-            HttpSetting::EnablePush(0),
-        ];
+        let settings = [HttpSetting::EnablePush(0)];
         let payload = {
             let mut res: Vec<u8> = Vec::new();
-            for s in settings.iter().map(|s| s.serialize()) { res.extend(s.to_vec().into_iter()); }
+            for s in settings.iter().map(|s| s.serialize()) {
+                res.extend(s.to_vec().into_iter());
+            }
 
             res
         };

--- a/src/http/frame/window_update.rs
+++ b/src/http/frame/window_update.rs
@@ -2,15 +2,8 @@
 
 use std::io;
 
-use http::{StreamId};
-use http::frame::{
-    Frame,
-    FrameIR,
-    FrameBuilder,
-    FrameHeader,
-    RawFrame,
-    NoFlag,
-};
+use http::StreamId;
+use http::frame::{Frame, FrameIR, FrameBuilder, FrameHeader, RawFrame, NoFlag};
 
 /// The minimum size for the `WINDOW_UPDATE` frame payload.
 pub const WINDOW_UPDATE_FRAME_LEN: u32 = 4;
@@ -75,10 +68,17 @@ impl<'a> Frame<'a> for WindowUpdateFrame {
         })
     }
 
-    fn is_set(&self, _: NoFlag) -> bool { false }
-    fn get_stream_id(&self) -> StreamId { self.stream_id }
+    fn is_set(&self, _: NoFlag) -> bool {
+        false
+    }
+    fn get_stream_id(&self) -> StreamId {
+        self.stream_id
+    }
     fn get_header(&self) -> FrameHeader {
-        (WINDOW_UPDATE_FRAME_LEN, WINDOW_UPDATE_FRAME_TYPE, self.flags, self.get_stream_id())
+        (WINDOW_UPDATE_FRAME_LEN,
+         WINDOW_UPDATE_FRAME_TYPE,
+         self.flags,
+         self.get_stream_id())
     }
 }
 

--- a/src/http/mod.rs
+++ b/src/http/mod.rs
@@ -140,8 +140,9 @@ impl<'n, 'v> Header<'n, 'v> {
     /// Creates a new `Header` with the given name and value.
     ///
     /// The name and value need to be convertible into a `HeaderPart`.
-    pub fn new<N: Into<HeaderPart<'n>>, V: Into<HeaderPart<'v>>>(name: N, value: V)
-            -> Header<'n, 'v> {
+    pub fn new<N: Into<HeaderPart<'n>>, V: Into<HeaderPart<'v>>>(name: N,
+                                                                 value: V)
+                                                                 -> Header<'n, 'v> {
         Header {
             name: name.into().0,
             value: value.into().0,
@@ -149,9 +150,13 @@ impl<'n, 'v> Header<'n, 'v> {
     }
 
     /// Return a borrowed representation of the `Header` name.
-    pub fn name(&self) -> &[u8] { &self.name }
+    pub fn name(&self) -> &[u8] {
+        &self.name
+    }
     /// Return a borrowed representation of the `Header` value.
-    pub fn value(&self) -> &[u8] { &self.value }
+    pub fn value(&self) -> &[u8] {
+        &self.value
+    }
 }
 
 impl<'n, 'v> Into<OwnedHeader> for Header<'n, 'v> {
@@ -172,12 +177,7 @@ impl<'n, 'v> Into<Header<'n, 'v>> for OwnedHeader {
 /// difference for all intents and purposes (and some servers out there still
 /// only officially advertise draft support).
 /// TODO: Eventually only use "h2".
-pub const ALPN_PROTOCOLS: &'static [&'static [u8]] = &[
-    b"h2",
-    b"h2-16",
-    b"h2-15",
-    b"h2-14",
-];
+pub const ALPN_PROTOCOLS: &'static [&'static [u8]] = &[b"h2", b"h2-16", b"h2-15", b"h2-14"];
 
 /// The enum represents an error code that are used in `RST_STREAM` and `GOAWAY` frames.
 /// These are defined in [Section 7](http://http2.github.io/http2-spec/#ErrorCodes) of the HTTP/2
@@ -394,17 +394,16 @@ impl PartialEq for HttpError {
         match (self, other) {
             (&HttpError::IoError(ref e1), &HttpError::IoError(ref e2)) => {
                 e1.kind() == e2.kind() && e1.description() == e2.description()
-            },
+            }
             (&HttpError::InvalidFrame, &HttpError::InvalidFrame) => true,
-            (&HttpError::CompressionError(ref e1), &HttpError::CompressionError(ref e2)) => {
-                e1 == e2
-            },
+            (&HttpError::CompressionError(ref e1),
+             &HttpError::CompressionError(ref e2)) => e1 == e2,
             (&HttpError::UnknownStreamId, &HttpError::UnknownStreamId) => true,
             (&HttpError::UnableToConnect, &HttpError::UnableToConnect) => true,
             (&HttpError::MalformedResponse, &HttpError::MalformedResponse) => true,
             (&HttpError::Other(ref e1), &HttpError::Other(ref e2)) => {
                 e1.description() == e2.description()
-            },
+            }
             _ => false,
         }
     }
@@ -442,7 +441,7 @@ impl WindowSize {
     pub fn try_increase(&mut self, delta: u32) -> Result<(), ()> {
         // Someone's provided a delta that would definitely overflow the window size.
         if delta > 0x7fffffff {
-            return Err(())
+            return Err(());
         }
         // Now it is safe to cast the delta to the `i32`.
         match self.0.checked_add(delta as i32) {
@@ -450,7 +449,7 @@ impl WindowSize {
                 // When the add overflows, we will have went over the maximum allowed size of the
                 // window size...
                 Err(())
-            },
+            }
             Some(next_val) => {
                 // The addition didn't overflow, so the next window size is in the range allowed by
                 // the spec.
@@ -488,7 +487,7 @@ impl WindowSize {
             Some(new) => {
                 self.0 = new;
                 Ok(())
-            },
+            }
             None => Err(()),
         }
     }
@@ -501,7 +500,9 @@ impl WindowSize {
     ///
     /// The size is actually allowed to become negative (for instance if the peer changes its
     /// intial window size in the settings); therefore, the return is an `i32`.
-    pub fn size(&self) -> i32 { self.0 }
+    pub fn size(&self) -> i32 {
+        self.0
+    }
 }
 
 /// An enum representing the two possible HTTP schemes.
@@ -547,8 +548,7 @@ pub type StaticResponse = Response<'static, 'static>;
 
 impl<'n, 'v> Response<'n, 'v> {
     /// Creates a new `Response` with all the components already provided.
-    pub fn new(stream_id: StreamId, headers: Vec<OwnedHeader>, body: Vec<u8>)
-            -> Response<'n, 'v> {
+    pub fn new(stream_id: StreamId, headers: Vec<OwnedHeader>, body: Vec<u8>) -> Response<'n, 'v> {
         Response {
             stream_id: stream_id,
             headers: headers.into_iter().map(|h| Header::new(h.0, h.1)).collect(),
@@ -565,7 +565,7 @@ impl<'n, 'v> Response<'n, 'v> {
         // field, the `:status` MUST be the first header; otherwise, the
         // response is malformed.
         if self.headers.len() < 1 {
-            return Err(HttpError::MalformedResponse)
+            return Err(HttpError::MalformedResponse);
         }
         if &self.headers[0].name[..] != &b":status"[..] {
             Err(HttpError::MalformedResponse)
@@ -593,8 +593,7 @@ impl<'n, 'v> Response<'n, 'v> {
         }
 
         // Finally, we can merge them into an integer
-        Ok(100 * ((buf[0] - b'0') as u16) +
-           10 * ((buf[1] - b'0') as u16) +
+        Ok(100 * ((buf[0] - b'0') as u16) + 10 * ((buf[1] - b'0') as u16) +
            1 * ((buf[2] - b'0') as u16))
     }
 }

--- a/src/http/session.rs
+++ b/src/http/session.rs
@@ -477,13 +477,22 @@ impl Stream for DefaultStream {
     }
 
     fn set_headers<'n, 'v>(&mut self, headers: Vec<Header<'n, 'v>>) {
-        self.headers = Some(headers.into_iter()
-                                   .map(|h| {
-                                       let owned: OwnedHeader = h.into();
-                                       owned.into()
-                                   })
-                                   .collect());
+        let mut new_headers = Vec::<Header<'static, 'static>>::new();
+
+        if let Some(hs) = self.headers.take() {
+            for h in hs {
+                new_headers.push(h)
+            }
+        }
+
+        for h in headers.into_iter() {
+            let owned: OwnedHeader = h.into();
+            new_headers.push(owned.into());
+        }
+
+        self.headers = Some(new_headers)
     }
+
     fn set_state(&mut self, state: StreamState) {
         self.state = state;
     }

--- a/src/http/session.rs
+++ b/src/http/session.rs
@@ -479,18 +479,18 @@ impl Stream for DefaultStream {
     fn set_headers<'n, 'v>(&mut self, headers: Vec<Header<'n, 'v>>) {
         let mut new_headers = Vec::<Header<'static, 'static>>::new();
 
-        if let Some(hs) = self.headers.take() {
-            for h in hs {
-                new_headers.push(h)
-            }
-        }
-
         for h in headers.into_iter() {
             let owned: OwnedHeader = h.into();
             new_headers.push(owned.into());
         }
 
-        self.headers = Some(new_headers)
+        self.headers = match self.headers.take() {
+            Some(mut x) => {
+                x.extend(new_headers);
+                Some(x)
+            }
+            None => Some(new_headers),
+        };
     }
 
     fn set_state(&mut self, state: StreamState) {

--- a/src/http/session.rs
+++ b/src/http/session.rs
@@ -11,7 +11,7 @@ use std::io::Cursor;
 use std::iter::FromIterator;
 use http::{StreamId, OwnedHeader, Header, HttpResult, ErrorCode, HttpError, ConnectionError};
 use http::frame::HttpSetting;
-use http::connection::{HttpConnection};
+use http::connection::HttpConnection;
 
 /// A trait that defines the interface between an `HttpConnection` and the higher-levels that use
 /// it. Essentially, it allows the `HttpConnection` to pass information onto those higher levels
@@ -23,28 +23,34 @@ pub trait Session {
     /// Notifies the `Session` that a new data chunk has arrived on the
     /// connection for a particular stream. Only the raw data is passed
     /// to the callback (all padding is already discarded by the connection).
-    fn new_data_chunk(&mut self, stream_id: StreamId, data: &[u8], conn: &mut HttpConnection)
-            -> HttpResult<()>;
+    fn new_data_chunk(&mut self,
+                      stream_id: StreamId,
+                      data: &[u8],
+                      conn: &mut HttpConnection)
+                      -> HttpResult<()>;
     /// Notifies the `Session` that headers have arrived for a particular
     /// stream. The given list of headers is already decoded by the connection.
     /// TODO: The Session should be notified separately for every header that is decoded.
-    fn new_headers<'n, 'v>(
-            &mut self,
-            stream_id: StreamId,
-            headers: Vec<Header<'n, 'v>>,
-            conn: &mut HttpConnection)
-            -> HttpResult<()>;
+    fn new_headers<'n, 'v>(&mut self,
+                           stream_id: StreamId,
+                           headers: Vec<Header<'n, 'v>>,
+                           conn: &mut HttpConnection)
+                           -> HttpResult<()>;
     /// Notifies the `Session` that a particular stream got closed by the peer.
-    fn end_of_stream(&mut self, stream_id: StreamId, conn: &mut HttpConnection)
-            -> HttpResult<()>;
+    fn end_of_stream(&mut self, stream_id: StreamId, conn: &mut HttpConnection) -> HttpResult<()>;
     /// Notifies the `Session` that a particular stream was reset by the peer and provides the
     /// reason behind it.
-    fn rst_stream(&mut self, stream_id: StreamId, error_code: ErrorCode, conn: &mut HttpConnection)
-            -> HttpResult<()>;
+    fn rst_stream(&mut self,
+                  stream_id: StreamId,
+                  error_code: ErrorCode,
+                  conn: &mut HttpConnection)
+                  -> HttpResult<()>;
     /// Notifies the `Session` that the peer has sent a new set of settings. The session itself is
     /// responsible for acknowledging the receipt of the settings.
-    fn new_settings(&mut self, settings: Vec<HttpSetting>, conn: &mut HttpConnection)
-            -> HttpResult<()>;
+    fn new_settings(&mut self,
+                    settings: Vec<HttpSetting>,
+                    conn: &mut HttpConnection)
+                    -> HttpResult<()>;
 
     /// Notifies the `Session` that the peer has sent a GOAWAY frame, indicating that the
     /// connection is terminated.
@@ -54,13 +60,12 @@ pub trait Session {
     ///
     /// Concrete `Session` implementations can override this in order to, for example, figure out
     /// which streams can be safely retried (based on the last processed stream id).
-    fn on_goaway(
-            &mut self,
-            _last_stream_id: StreamId,
-            error_code: ErrorCode,
-            debug_data: Option<&[u8]>,
-            _conn: &mut HttpConnection)
-            -> HttpResult<()> {
+    fn on_goaway(&mut self,
+                 _last_stream_id: StreamId,
+                 error_code: ErrorCode,
+                 debug_data: Option<&[u8]>,
+                 _conn: &mut HttpConnection)
+                 -> HttpResult<()> {
         Err(HttpError::PeerConnectionError(ConnectionError {
             error_code: error_code,
             debug_data: debug_data.map(|data| data.to_vec()),
@@ -72,13 +77,17 @@ pub trait Session {
 ///
 /// Allows `SessionState` implementations to return iterators over its session without being forced
 /// to declare them as associated types.
-pub struct StreamIter<'a, S: Stream + 'a>(Box<Iterator<Item=(&'a StreamId, &'a mut S)> + 'a>);
+pub struct StreamIter<'a, S: Stream + 'a>(Box<Iterator<Item = (&'a StreamId, &'a mut S)> + 'a>);
 
-impl<'a, S> Iterator for StreamIter<'a, S> where S: Stream + 'a {
+impl<'a, S> Iterator for StreamIter<'a, S>
+    where S: Stream + 'a
+{
     type Item = (&'a StreamId, &'a mut S);
 
     #[inline]
-    fn next(&mut self) -> Option<(&'a StreamId, &'a mut S)> { self.0.next() }
+    fn next(&mut self) -> Option<(&'a StreamId, &'a mut S)> {
+        self.0.next()
+    }
 }
 
 /// A trait defining a set of methods for accessing and influencing an HTTP/2 session's state.
@@ -122,10 +131,15 @@ pub trait SessionState {
     /// The default implementations relies on the `iter` implementation to find the closed streams
     /// first and then calls `remove_stream` on all of them.
     fn get_closed(&mut self) -> Vec<Self::Stream> {
-        let ids: Vec<StreamId> =
-            self.iter().filter_map(|(id, s)| {
-                if s.is_closed() { Some(*id) } else { None }
-            }).collect();
+        let ids: Vec<StreamId> = self.iter()
+                                     .filter_map(|(id, s)| {
+                                         if s.is_closed() {
+                                             Some(*id)
+                                         } else {
+                                             None
+                                         }
+                                     })
+                                     .collect();
         FromIterator::from_iter(ids.into_iter().map(|i| self.remove_stream(i).unwrap()))
     }
 }
@@ -160,7 +174,9 @@ impl Parity {
 
 /// An implementation of the `SessionState` trait that tracks the active streams in a `HashMap`,
 /// mapping the stream ID to the concrete `Stream` instance.
-pub struct DefaultSessionState<T, S> where S: Stream {
+pub struct DefaultSessionState<T, S>
+    where S: Stream
+{
     /// All streams that the session state is currently aware of.
     streams: HashMap<StreamId, S>,
     /// The next available ID for outgoing streams.
@@ -175,7 +191,9 @@ pub struct DefaultSessionState<T, S> where S: Stream {
     _server_or_client: PhantomData<T>,
 }
 
-impl<T, S> DefaultSessionState<T, S> where S: Stream {
+impl<T, S> DefaultSessionState<T, S>
+    where S: Stream
+{
     /// A helper function that returns `true` iff the given `StreamId` is a valid ID for an
     /// incoming stream, depending on whether the session is that of a client or a server.
     fn validate_incoming_parity(&self, stream_id: StreamId) -> bool {
@@ -184,7 +202,9 @@ impl<T, S> DefaultSessionState<T, S> where S: Stream {
     }
 }
 
-impl<S> DefaultSessionState<Client, S> where S: Stream {
+impl<S> DefaultSessionState<Client, S>
+    where S: Stream
+{
     /// Creates a new `DefaultSessionState` for a client session with no known streams.
     pub fn new() -> DefaultSessionState<Client, S> {
         DefaultSessionState {
@@ -196,7 +216,9 @@ impl<S> DefaultSessionState<Client, S> where S: Stream {
     }
 }
 
-impl<S> DefaultSessionState<Server, S> where S: Stream {
+impl<S> DefaultSessionState<Server, S>
+    where S: Stream
+{
     /// Creates a new `DefaultSessionState` for a server session with no known streams.
     pub fn new() -> DefaultSessionState<Server, S> {
         DefaultSessionState {
@@ -221,7 +243,9 @@ pub fn default_server_state<S: Stream>() -> DefaultSessionState<Server, S> {
     DefaultSessionState::<Server, S>::new()
 }
 
-impl<T, S> SessionState for DefaultSessionState<T, S> where S: Stream {
+impl<T, S> SessionState for DefaultSessionState<T, S>
+    where S: Stream
+{
     type Stream = S;
 
     fn insert_outgoing(&mut self, stream: Self::Stream) -> StreamId {
@@ -238,7 +262,7 @@ impl<T, S> SessionState for DefaultSessionState<T, S> where S: Stream {
                 // TODO(mlalic): Assert that the stream IDs are monotonically increasing!
                 self.streams.insert(stream_id, stream);
                 Ok(())
-            },
+            }
         }
     }
 
@@ -286,8 +310,12 @@ pub enum StreamDataError {
     Other(Box<Error + Send + Sync>),
 }
 
-impl<E> From<E> for StreamDataError where E: Error + Send + Sync + 'static {
-    fn from(err: E) -> StreamDataError { StreamDataError::Other(Box::new(err)) }
+impl<E> From<E> for StreamDataError
+    where E: Error + Send + Sync + 'static
+{
+    fn from(err: E) -> StreamDataError {
+        StreamDataError::Other(Box::new(err))
+    }
 }
 
 /// The enum represents the successful completion of the `Stream::get_data_chunk` method.
@@ -347,7 +375,9 @@ pub trait Stream {
 
     /// Transitions the stream state to closed. After this, the stream is considered to be closed
     /// for any further reads or writes.
-    fn close(&mut self) { self.set_state(StreamState::Closed); }
+    fn close(&mut self) {
+        self.set_state(StreamState::Closed);
+    }
     /// Updates the `Stream` status to indicate that it is closed locally.
     ///
     /// If the stream is closed on the remote end, then it is fully closed after this call.
@@ -371,7 +401,9 @@ pub trait Stream {
     /// Returns whether the stream is closed.
     ///
     /// A stream is considered to be closed iff its state is set to `Closed`.
-    fn is_closed(&self) -> bool { self.state() == StreamState::Closed }
+    fn is_closed(&self) -> bool {
+        self.state() == StreamState::Closed
+    }
     /// Returns whether the stream is closed locally.
     fn is_closed_local(&self) -> bool {
         match self.state() {
@@ -445,14 +477,20 @@ impl Stream for DefaultStream {
     }
 
     fn set_headers<'n, 'v>(&mut self, headers: Vec<Header<'n, 'v>>) {
-        self.headers = Some(headers.into_iter().map(|h| {
-            let owned: OwnedHeader = h.into();
-            owned.into()
-        }).collect());
+        self.headers = Some(headers.into_iter()
+                                   .map(|h| {
+                                       let owned: OwnedHeader = h.into();
+                                       owned.into()
+                                   })
+                                   .collect());
     }
-    fn set_state(&mut self, state: StreamState) { self.state = state; }
+    fn set_state(&mut self, state: StreamState) {
+        self.state = state;
+    }
 
-    fn state(&self) -> StreamState { self.state }
+    fn state(&self) -> StreamState {
+        self.state
+    }
 
     fn get_data_chunk(&mut self, buf: &mut [u8]) -> Result<StreamDataChunk, StreamDataError> {
         if self.is_closed_local() {
@@ -461,7 +499,7 @@ impl Stream for DefaultStream {
         let chunk = match self.data.as_mut() {
             // No data associated to the stream, but it's open => nothing available for writing
             None => StreamDataChunk::Unavailable,
-            Some(d) =>  {
+            Some(d) => {
                 // For the `Vec`-backed reader, this should never fail, so unwrapping is
                 // fine.
                 let read = d.read(buf).unwrap();
@@ -475,7 +513,7 @@ impl Stream for DefaultStream {
         // Transition the stream state to locally closed if we've extracted the final data chunk.
         match chunk {
             StreamDataChunk::Last(_) => self.close_local(),
-            _ => {},
+            _ => {}
         };
 
         Ok(chunk)
@@ -484,14 +522,8 @@ impl Stream for DefaultStream {
 
 #[cfg(test)]
 mod tests {
-    use super::{
-        Stream,
-        DefaultSessionState,
-        DefaultStream,
-        StreamDataChunk, StreamDataError,
-        SessionState,
-        Parity,
-    };
+    use super::{Stream, DefaultSessionState, DefaultStream, StreamDataChunk, StreamDataError,
+                SessionState, Parity};
     use super::Client as ClientMarker;
     use super::Server as ServerMarker;
     use http::ErrorCode;
@@ -608,7 +640,9 @@ mod tests {
     fn test_default_stream_get_data() {
         // The buffer that will be used in upcoming tests
         let mut buf = Vec::with_capacity(2);
-        unsafe { buf.set_len(2); }
+        unsafe {
+            buf.set_len(2);
+        }
 
         {
             // A newly open stream has no available data.

--- a/src/http/session.rs
+++ b/src/http/session.rs
@@ -477,19 +477,17 @@ impl Stream for DefaultStream {
     }
 
     fn set_headers<'n, 'v>(&mut self, headers: Vec<Header<'n, 'v>>) {
-        let mut new_headers = Vec::<Header<'static, 'static>>::new();
-
-        for h in headers.into_iter() {
+        let new_headers = headers.into_iter().map(|h| {
             let owned: OwnedHeader = h.into();
-            new_headers.push(owned.into());
-        }
+            owned.into()
+        });
 
         self.headers = match self.headers.take() {
             Some(mut x) => {
-                x.extend(new_headers);
+                x.extend(new_headers.collect::<Vec<Header<'static, 'static>>>());
                 Some(x)
             }
-            None => Some(new_headers),
+            None => Some(new_headers.collect()),
         };
     }
 

--- a/src/http/tests/mod.rs
+++ b/src/http/tests/mod.rs
@@ -13,36 +13,31 @@ mod root_tests {
     fn test_parse_status_code_response() {
         {
             // Only status => Ok
-            let resp = Response::new(
-                1,
-                vec![(b":status".to_vec(), b"200".to_vec())],
-                vec![]);
+            let resp = Response::new(1, vec![(b":status".to_vec(), b"200".to_vec())], vec![]);
             assert_eq!(resp.status_code().ok().unwrap(), 200);
         }
         {
             // Extra headers => still works
-            let resp = Response::new(
-                1,
-                vec![(b":status".to_vec(), b"200".to_vec()),
-                (b"key".to_vec(), b"val".to_vec())],
-                vec![]);
+            let resp = Response::new(1,
+                                     vec![(b":status".to_vec(), b"200".to_vec()),
+                                          (b"key".to_vec(), b"val".to_vec())],
+                                     vec![]);
             assert_eq!(resp.status_code().ok().unwrap(), 200);
         }
         {
             // Status is not the first header => malformed
-            let resp = Response::new(
-                1,
-                vec![(b"key".to_vec(), b"val".to_vec()),
-                (b":status".to_vec(), b"200".to_vec())],
-                vec![]);
+            let resp = Response::new(1,
+                                     vec![(b"key".to_vec(), b"val".to_vec()),
+                                          (b":status".to_vec(), b"200".to_vec())],
+                                     vec![]);
             assert_eq!(resp.status_code().err().unwrap(),
-            HttpError::MalformedResponse);
+                       HttpError::MalformedResponse);
         }
         {
             // No headers at all => Malformed
             let resp = Response::new(1, vec![], vec![]);
             assert_eq!(resp.status_code().err().unwrap(),
-            HttpError::MalformedResponse);
+                       HttpError::MalformedResponse);
         }
     }
 
@@ -143,11 +138,11 @@ mod test_header {
 
         match clone.name {
             Cow::Owned(_) => panic!("Expected a borrowed name"),
-            _ => {},
+            _ => {}
         };
         match clone.value {
             Cow::Owned(_) => panic!("Expected a borrowed value"),
-            _ => {},
+            _ => {}
         };
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,12 +1,13 @@
 #![doc(html_root_url="https://mlalic.github.io/solicit/")]
 
-#[macro_use] extern crate log;
+#[macro_use]
+extern crate log;
 extern crate hpack;
-#[cfg(feature="tls")] extern crate openssl;
+#[cfg(feature="tls")]
+extern crate openssl;
 
 pub mod http;
 pub mod client;
 pub mod server;
 
-mod tests {
-}
+mod tests {}


### PR DESCRIPTION
This is a simple fix for #9.

This is imperfect because you can't tell what is a trailer and what is a
header, but it solicit from choking when a HTTP/2 servers sends
trailers.

Previously solicit was overwriting the existing headers, and then
declaring the stream Malformed when it was unable to find the :status
header.