### PR TITLE
Improve error handling in async client

### DIFF
--- a/src/client/async.rs
+++ b/src/client/async.rs
@@ -430,7 +430,7 @@ impl ClientService {
                 Ok(())
             }
             WorkItem::NewClient => {
-                self.client_count += 1;
+                self.on_new_client();
                 Ok(())
             }
             WorkItem::ClientLeft => {
@@ -442,6 +442,10 @@ impl ClientService {
                 }
             }
         }
+    }
+
+    fn on_new_client(&mut self) {
+        self.client_count += 1;
     }
 
     /// A private convenience method that performs the handling of the next received frame.
@@ -659,7 +663,7 @@ impl Client {
 
         let Service(mut service, rx, mut recv_frame, mut send_frame) = service;
 
-        rx.send(WorkItem::NewClient).expect("service is in scope and holds the receiver");
+        service.on_new_client();
 
         // Keep a handle to the work queue to notify the service of newly read frames, making it so
         // that it never blocks on waiting for frames to read.

--- a/src/client/tests.rs
+++ b/src/client/tests.rs
@@ -113,6 +113,6 @@ mod async {
         let connector = CleartextConnector::new("unknown.host.name.lcl");
         let client = Client::with_connector(connector);
 
-        assert!(client.is_none());
+        assert!(client.is_err());
     }
 }


### PR DESCRIPTION
The async `Client::with_connector` method returns a Result.  This
improves Error handling capability for consumers of the async client.
Previously, an Option<Client> was returned which offered no
introspection of what went wrong.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mlalic/solicit/20)
<!-- Reviewable:end -->
