### PR TITLE
Add support for PING frame

### DIFF
--- a/src/http/frame/mod.rs
+++ b/src/http/frame/mod.rs
@@ -45,6 +45,7 @@ pub mod headers;
 pub mod rst_stream;
 pub mod settings;
 pub mod goaway;
+pub mod ping;
 pub mod window_update;
 
 pub use self::builder::FrameBuilder;
@@ -57,6 +58,7 @@ pub use self::rst_stream::RstStreamFrame;
 /// Rexports related to the `SETTINGS` frame.
 pub use self::settings::{SettingsFlag, SettingsFrame, HttpSetting};
 pub use self::goaway::GoawayFrame;
+pub use self::ping::PingFrame;
 pub use self::window_update::WindowUpdateFrame;
 
 /// An alias for the 9-byte buffer that each HTTP/2 frame header must be stored

--- a/src/http/frame/ping.rs
+++ b/src/http/frame/ping.rs
@@ -1,0 +1,156 @@
+//! Implements the `PING` HTTP/2 frame.
+
+use std::io;
+
+use http::StreamId;
+use http::frame::{
+    Frame,
+    FrameIR,
+    FrameBuilder,
+    FrameHeader,
+    RawFrame,
+    Flag,
+};
+
+/// Ping frames are always 8 bytes
+pub const PING_FRAME_LEN: u32 = 8;
+/// The frame type of the `PING` frame.
+pub const PING_FRAME_TYPE: u8 = 0x6;
+
+pub struct PingFlag;
+impl Flag for PingFlag {
+    fn bitmask(&self) -> u8 {
+        0x1
+    }
+}
+
+/// The struct represents the `PINg` HTTP/2 frame.
+#[derive(Clone, Debug, PartialEq)]
+pub struct PingFrame {
+    opaque_data: u64,
+    flags: u8,
+}
+
+impl PingFrame {
+    /// Create a new `PING` frame
+    pub fn new() -> Self {
+        PingFrame {
+            opaque_data: 0,
+            flags: 0,
+        }
+    }
+
+    /// Create a new PING frame with ACK set
+    pub fn new_ack(opaque_data: u64) -> Self {
+        PingFrame {
+            opaque_data: opaque_data,
+            flags: 1,
+        }
+    }
+
+    /// Create a new `PING` frame with the given opaque_data
+    pub fn with_data(opaque_data: u64) -> Self {
+        PingFrame {
+            opaque_data: opaque_data,
+            flags: 0,
+        }
+    }
+
+    pub fn is_ack(&self) -> bool {
+        self.is_set(PingFlag)
+    }
+
+    pub fn opaque_data(&self) -> u64 {
+        self.opaque_data
+    }
+}
+
+impl<'a> Frame<'a> for PingFrame {
+    type FlagType = PingFlag;
+
+    fn from_raw(raw_frame: &'a RawFrame<'a>) -> Option<Self> {
+        let (payload_len, frame_type, flags, stream_id) = raw_frame.header();
+        if payload_len != PING_FRAME_LEN {
+            return None;
+        }
+        if frame_type != PING_FRAME_TYPE {
+            return None;
+        }
+        if stream_id != 0x0 {
+            return None;
+        }
+
+        let data = unpack_octets_4!(raw_frame.payload(), 0, u64) << 32 |
+                   unpack_octets_4!(raw_frame.payload(), 4, u64);
+
+        Some(PingFrame {
+            opaque_data: data,
+            flags: flags,
+        })
+    }
+
+    fn is_set(&self, flag: PingFlag) -> bool {
+        (flag.bitmask() & self.flags) != 0
+    }
+
+    fn get_stream_id(&self) -> StreamId {
+        0
+    }
+
+    fn get_header(&self) -> FrameHeader {
+        (PING_FRAME_LEN, PING_FRAME_TYPE, self.flags, 0)
+    }
+}
+
+impl<'a> FrameIR for PingFrame {
+    fn serialize_into<B: FrameBuilder>(self, builder: &mut B) -> io::Result<()> {
+        try!(builder.write_header(self.get_header()));
+        try!(builder.write_u32((self.opaque_data >> 32) as u32));
+        try!(builder.write_u32(self.opaque_data as u32));
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::PingFrame;
+
+    use http::tests::common::{serialize_frame, raw_frame_from_parts};
+    use http::frame::Frame;
+
+    #[test]
+    fn test_parse_not_ack() {
+        let raw = raw_frame_from_parts((8, 0x6, 0, 0), vec![0, 0, 0, 0, 0, 0, 0, 0]);
+        let frame = PingFrame::from_raw(&raw).expect("Expected successful parse");
+        assert_eq!(frame.is_ack(), false);
+        assert_eq!(frame.opaque_data(), 0);
+    }
+
+    #[test]
+    fn test_parse_ack() {
+        let raw = raw_frame_from_parts((8, 0x6, 1, 0), vec![0, 0, 0, 0, 0, 0, 0, 0]);
+        let frame = PingFrame::from_raw(&raw).expect("Expected successful parse");
+        assert_eq!(frame.is_ack(), true);
+        assert_eq!(frame.opaque_data(), 0);
+    }
+
+    #[test]
+    fn test_parse_opaque_data() {
+        let raw = raw_frame_from_parts((8, 0x6, 1, 0), vec![1, 2, 3, 4, 5, 6, 7, 8]);
+        let frame = PingFrame::from_raw(&raw).expect("Expected successful parse");
+        assert_eq!(frame.is_ack(), true);
+        assert_eq!(frame.opaque_data(), 0x0102030405060708);
+    }
+
+    #[test]
+    fn test_serialize() {
+        let frame = PingFrame::new_ack(0);
+        let expected: Vec<u8> = raw_frame_from_parts(
+            (8, 0x6, 1, 0),
+            vec![0, 0, 0, 0, 0, 0, 0, 0]).into();
+
+        let raw = serialize_frame(&frame);
+
+        assert_eq!(expected, raw);
+    }
+}

--- a/src/http/server.rs
+++ b/src/http/server.rs
@@ -2,7 +2,7 @@
 //! HTTP/2 connection.
 
 use http::{StreamId, Header, HttpResult, HttpScheme, ErrorCode};
-use http::frame::HttpSetting;
+use http::frame::{HttpSetting, PingFrame};
 use http::connection::{SendFrame, ReceiveFrame, HttpConnection, EndStream, SendStatus};
 use http::session::{Session, SessionState, Stream, DefaultStream, DefaultSessionState};
 use http::session::Server as ServerMarker;
@@ -120,6 +120,16 @@ impl<'a, State, F, S> Session for ServerSession<'a, State, F, S>
                     -> HttpResult<()> {
         debug!("Sending a SETTINGS ack");
         conn.sender(self.sender).send_settings_ack()
+    }
+
+    fn on_ping(&mut self, ping: &PingFrame, conn: &mut HttpConnection) -> HttpResult<()> {
+        debug!("Sending a PING ack");
+        conn.sender(self.sender).send_ping_ack(ping.opaque_data())
+    }
+
+    fn on_pong(&mut self, _ping: &PingFrame, _conn: &mut HttpConnection) -> HttpResult<()> {
+        debug!("Received a PING ack");
+        Ok(())
     }
 }
 

--- a/src/http/session.rs
+++ b/src/http/session.rs
@@ -10,7 +10,7 @@ use std::io::Read;
 use std::io::Cursor;
 use std::iter::FromIterator;
 use http::{StreamId, OwnedHeader, Header, HttpResult, ErrorCode, HttpError, ConnectionError};
-use http::frame::HttpSetting;
+use http::frame::{HttpSetting, PingFrame};
 use http::connection::HttpConnection;
 
 /// A trait that defines the interface between an `HttpConnection` and the higher-levels that use
@@ -51,6 +51,13 @@ pub trait Session {
                     settings: Vec<HttpSetting>,
                     conn: &mut HttpConnection)
                     -> HttpResult<()>;
+
+    /// Notifies the `Session` that a PING request has been received. The session itself is
+    /// responsible for replying with an ACK.
+    fn on_ping(&mut self, ping: &PingFrame, conn: &mut HttpConnection) -> HttpResult<()>;
+
+    /// Notifies the `Session` that a PING acknowledgement has been received.
+    fn on_pong(&mut self, ping: &PingFrame, conn: &mut HttpConnection) -> HttpResult<()>;
 
     /// Notifies the `Session` that the peer has sent a GOAWAY frame, indicating that the
     /// connection is terminated.

--- a/src/http/tests/common.rs
+++ b/src/http/tests/common.rs
@@ -7,7 +7,7 @@ use std::borrow::Cow;
 use std::io::{Cursor, Read, Write};
 
 use http::{HttpResult, HttpScheme, StreamId, Header, OwnedHeader, ErrorCode};
-use http::frame::{RawFrame, FrameIR, FrameHeader, pack_header, HttpSetting};
+use http::frame::{RawFrame, FrameIR, FrameHeader, pack_header, HttpSetting, PingFrame};
 use http::session::{Session, DefaultSessionState, SessionState, Stream, StreamState,
                     StreamDataChunk, StreamDataError};
 use http::session::Client as ClientMarker;
@@ -167,6 +167,7 @@ pub fn build_stub_from_frames(frames: &Vec<HttpFrame>) -> Vec<u8> {
             HttpFrame::HeadersFrame(ref frame) => serialize_frame(frame),
             HttpFrame::RstStreamFrame(ref frame) => serialize_frame(frame),
             HttpFrame::SettingsFrame(ref frame) => serialize_frame(frame),
+            HttpFrame::PingFrame(ref frame) => serialize_frame(frame),
             HttpFrame::GoawayFrame(ref frame) => serialize_frame(frame),
             HttpFrame::WindowUpdateFrame(ref frame) => serialize_frame(frame),
             HttpFrame::UnknownFrame(ref frame) => serialize_frame(frame),
@@ -332,6 +333,14 @@ impl Session for TestSession {
                  _: &mut HttpConnection)
                  -> HttpResult<()> {
         self.goaways.push(error_code);
+        Ok(())
+    }
+
+    fn on_ping(&mut self, _ping: &PingFrame, _conn: &mut HttpConnection) -> HttpResult<()> {
+        Ok(())
+    }
+
+    fn on_pong(&mut self, _ping: &PingFrame, _conn: &mut HttpConnection) -> HttpResult<()> {
         Ok(())
     }
 }

--- a/src/http/transport.rs
+++ b/src/http/transport.rs
@@ -192,7 +192,12 @@ mod tests {
                 let ret = serialize_frame(&frame);
                 sender.send_frame(frame).unwrap();
                 ret
-            }
+            },
+            HttpFrame::PingFrame(frame) => {
+                let ret = serialize_frame(&frame);
+                sender.send_frame(frame).unwrap();
+                ret
+            },
             HttpFrame::GoawayFrame(frame) => {
                 let ret = serialize_frame(&frame);
                 sender.send_frame(frame).unwrap();


### PR DESCRIPTION
The protocol specifies a few things that could not be handled here due
to current Solicit APIs.

> If a PING frame is received with a stream identifier field value other
> than 0x0, the recipient MUST respond with a connection error (Section
> 5.4.1) of type PROTOCOL_ERROR.

and

> Receipt of a PING frame with a length field value other than 8 MUST be
> treated as a connection error (Section 5.4.1) of type
> FRAME_SIZE_ERROR.

When receiving a PING frame without the ACK flag set, the connection
replies with a PING frame having the ACK flag set. When an ACK is
received, nothing is done.

In addition to supporting the PING frame of the HTTP/2 protocol, a
method is exposed on the Async client to support sending PINGs as
desired by the client. This part of the feature is a bit half-baked as
the client has no way of getting the PONG. It wasn't clear how this
API should work. At the very least, it provides a method which will send
PING frames and return an error immediately if the client isn't capable
of making requests.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mlalic/solicit/21)
<!-- Reviewable:end -->
