### PR TITLE
rust-openssl 0.7 support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,10 +17,11 @@ hpack = "0.3"
 log = "^0.3"
 
 [dependencies.openssl]
-version = "0.6"
-features = ["tlsv1_2", "npn"]
+# >= 0.7.9 is required for SslStream to be Send
+version = "0.7.9"
+features = ["tlsv1_2", "alpn"]
 optional = true
 
 [features]
 live_tests = []
-tls = ["openssl", "openssl/tlsv1_2", "openssl/npn"]
+tls = ["openssl", "openssl/tlsv1_2", "openssl/alpn"]

--- a/src/http/client/tls.rs
+++ b/src/http/client/tls.rs
@@ -210,7 +210,7 @@ impl<'a, 'ctx> TlsConnector<'a, 'ctx> {
         // Compression is not allowed by the spec
         context.set_options(SSL_OP_NO_COMPRESSION);
         // The HTTP/2 protocol identifiers are constant at the library level...
-        context.set_npn_protocols(ALPN_PROTOCOLS);
+        context.set_alpn_protocols(ALPN_PROTOCOLS);
 
         Ok(context)
     }
@@ -236,10 +236,10 @@ impl<'a, 'ctx> HttpConnect for TlsConnector<'a, 'ctx> {
         try!(ssl.set_hostname(self.host));
 
         // Wrap the Ssl instance into an `SslStream`
-        let mut ssl_stream = try!(SslStream::new_from(ssl, raw_tcp));
+        let mut ssl_stream = try!(SslStream::connect(ssl, raw_tcp));
         // This connector only understands HTTP/2, so if that wasn't chosen in
-        // NPN, we raise an error.
-        let fail = match ssl_stream.get_selected_npn_protocol() {
+        // ALPN, we raise an error.
+        let fail = match ssl_stream.ssl().selected_alpn_protocol() {
             None => true,
             Some(proto) => {
                 // Make sure that the protocol is one of the HTTP/2 protocols.


### PR DESCRIPTION
The HTTP/2 spec requires the TLS application-layer protocol negotiation
(ALPN) extension from the TLS library. This was added to openssl 1.0.2
which became available in rust-openssl 0.7.

I would have submitted this sooner, but the feature was blocked on `SslStream` not being `Send` in early patch versions of rust-openssl 0.7.x.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mlalic/solicit/23)

<!-- Reviewable:end -->
