### PR TITLE
SendFrame only requires Write

### DIFF
--- a/src/http/transport.rs
+++ b/src/http/transport.rs
@@ -80,7 +80,7 @@ impl TransportStream for TcpStream {
 }
 
 impl<T> SendFrame for T
-    where T: TransportStream
+    where T: Write
 {
     fn send_frame<F: FrameIR>(&mut self, frame: F) -> HttpResult<()> {
         let mut buf = io::Cursor::new(Vec::with_capacity(1024));


### PR DESCRIPTION
Whole `TransportStream` is not needed.

It is problem, because, for example, `conn.send_next_data(..)` cannot be (easily) called with `Vec<u8>` argument, which implements `Write`, but not `TransportStream`.
