### PR TITLE
make HttpConnection::handle_frame public

### DIFF
--- a/src/http/connection.rs
+++ b/src/http/connection.rs
@@ -420,7 +420,7 @@ impl HttpConnection {
     }
 
     /// Private helper method that actually handles a received frame.
-    fn handle_frame<Sess: Session>(&mut self,
+    pub fn handle_frame<Sess: Session>(&mut self,
                                    frame: HttpFrame,
                                    session: &mut Sess)
                                    -> HttpResult<()> {


### PR DESCRIPTION
asynchronous server must not block in `rx.recv_frame()`, so
`handle_next_frame` is not suitable for asynchronous server.

The workaround this limitation is to implement `ReceiveFrame` which
produces one previously read frame, but making `handle_frame` public
is more straightforward.
