### PR TITLE
make StreamIter constructor public

### DIFF
--- a/src/http/session.rs
+++ b/src/http/session.rs
@@ -84,7 +84,7 @@ pub trait Session {
 ///
 /// Allows `SessionState` implementations to return iterators over its session without being forced
 /// to declare them as associated types.
-pub struct StreamIter<'a, S: Stream + 'a>(Box<Iterator<Item = (&'a StreamId, &'a mut S)> + 'a>);
+pub struct StreamIter<'a, S: Stream + 'a>(pub Box<Iterator<Item = (&'a StreamId, &'a mut S)> + 'a>);
 
 impl<'a, S> Iterator for StreamIter<'a, S>
     where S: Stream + 'a


### PR DESCRIPTION
... otherwise it is not possible to implement SessionState
